### PR TITLE
Fix ie crash due to compiled source using Symbol

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,8 +15,7 @@
 		},
 		"production": {
 			"plugins": [
-				"transform-react-constant-elements",
-				"transform-react-inline-elements"
+				"transform-react-constant-elements"
 			]
 		}
 	}

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-# Src folder is needed for IE
-# src
+src

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "react-vscroll",
-  "private": true,
   "license": "Apache-2.0",
   "version": "1.0.0",
   "description": "",
@@ -34,7 +33,6 @@
     "babel-loader": "6.2.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-react-constant-elements": "6.5.0",
-    "babel-plugin-transform-react-inline-elements": "6.6.5",
     "babel-polyfill": "6.7.4",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.3.13",


### PR DESCRIPTION
This PR fixes a bug with compiled vscroll script failing on IE11. 

```
Objects are not valid as a React child (found: object with keys {$$typeof..........
```

The build plugin https://babeljs.io/docs/plugins/transform-react-inline-elements/ assumes the presence of `Symbol`, but as we do not have it in IE nor polyfilling it in our apps, its simpler to just remove this.
